### PR TITLE
fix: out of memory

### DIFF
--- a/functions/src/v1/firestore/admin/user/year/entry/onCreate.ts
+++ b/functions/src/v1/firestore/admin/user/year/entry/onCreate.ts
@@ -21,6 +21,7 @@ const path =
 export const onCreate = () =>
   functions()
     .runWith({
+      memory: '256MB',
       secrets: [
         'FEE_BILLING_ACCOUNT_PRIVATE_KEY',
         'MESSAGE_RECEIVING_ACCOUNT_PRIVATE_KEY',

--- a/functions/src/v1/firestore/admin/user/year/judge/onUpdate.ts
+++ b/functions/src/v1/firestore/admin/user/year/judge/onUpdate.ts
@@ -26,6 +26,7 @@ const path = '/v/1/scopes/admin/users/{userID}/years/{yearID}/judges/{judgeID}';
 export const onUpdate = () =>
   functions()
     .runWith({
+      memory: '256MB',
       secrets: [
         'FEE_BILLING_ACCOUNT_PRIVATE_KEY',
         'MESSAGE_RECEIVING_ACCOUNT_PRIVATE_KEY',

--- a/functions/src/v1/firestore/admin/user/year/submission/onUpdate.ts
+++ b/functions/src/v1/firestore/admin/user/year/submission/onUpdate.ts
@@ -23,6 +23,7 @@ const path =
 export const onUpdate = () =>
   functions()
     .runWith({
+      memory: '256MB',
       secrets: [
         'FEE_BILLING_ACCOUNT_PRIVATE_KEY',
         'MESSAGE_RECEIVING_ACCOUNT_PRIVATE_KEY',

--- a/functions/src/v1/firestore/admin/user/year/team/onUpdate.ts
+++ b/functions/src/v1/firestore/admin/user/year/team/onUpdate.ts
@@ -21,6 +21,7 @@ const path = '/v/1/scopes/admin/users/{userID}/years/{yearID}/teams/{teamID}';
 export const onUpdate = () =>
   functions()
     .runWith({
+      memory: '256MB',
       secrets: [
         'FEE_BILLING_ACCOUNT_PRIVATE_KEY',
         'MESSAGE_RECEIVING_ACCOUNT_PRIVATE_KEY',

--- a/functions/src/v1/firestore/admin/user/year/vote/onUpdate.ts
+++ b/functions/src/v1/firestore/admin/user/year/vote/onUpdate.ts
@@ -26,6 +26,7 @@ const path = '/v/1/scopes/admin/users/{userID}/years/{yearID}/votes/{voteID}';
 export const onUpdate = () =>
   functions()
     .runWith({
+      memory: '256MB',
       secrets: [
         'FEE_BILLING_ACCOUNT_PRIVATE_KEY',
         'MESSAGE_RECEIVING_ACCOUNT_PRIVATE_KEY',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19937,9 +19937,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -37230,9 +37230,9 @@
       }
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "requires": {
         "lru-cache": "^6.0.0"
       }


### PR DESCRIPTION
- [x] Fix out of memory in v1-firestore-admin-user-year-submission-onUpdate Cloud Functions for Firebase.
- [x] Fix out of memory preventively in
  - [x] v1-firestore-admin-user-year-entry-onCreate
  - [x] v1-firestore-admin-user-year-judge-onCreate
  - [x] v1-firestore-admin-user-year-team-onCreate
  - [x] v1-firestore-admin-user-year-vote-onCreate

```
Memory limit of 128 MiB exceeded with 137 MiB used. Consider increasing the memory limit, see https://cloud.google.com/functions/docs/configuring/memory
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the memory configuration for the user submission update process to enhance performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->