### PR TITLE
fix: add final vote and judge point to award page

### DIFF
--- a/src/components/pages/years/[yearId]/awards/index.tsx
+++ b/src/components/pages/years/[yearId]/awards/index.tsx
@@ -67,7 +67,9 @@ const PublicAwardsPageComponent = () => {
                   <div className="card-title justify-end">
                     Total Points:{publicResult.totalPoints} = Judge Points:
                     {publicResult.judgesTotalPoints} + Vote Points:
-                    {publicResult.votesTotalPoints}
+                    {publicResult.votesTotalPoints} + Final Judge Points:{' '}
+                    {publicResult.finalJudgesTotalPoints} + Final Vote Points:{' '}
+                    {publicResult.finalVotesTotalPoints}
                   </div>
                 </div>
                 <PublicSubmissionCardWidgetComponent


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- On the Public Awards page, now displays final judge points and final vote points in the total points calculation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->